### PR TITLE
Add element

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +185,7 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 name = "rusty-merkle-tree"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "sha256",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+lazy_static = "1.5.0"
 sha256 = "1.6.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ impl MerkleTree {
 
 type Input = Vec<Vec<u8>>;
 
-/// Allows the creationg of a Merkle Tree from its base level (or leaves level) which are the hashes of the original
+/// Allows the creation of a Merkle Tree from its base level (or leaves level) which are the hashes of the original
 /// data. This function is useful to extend the Merkle Tree when adding a new element.
 fn create_merkle_tree_from_leaves(leaves: Vec<String>) -> Vec<Vec<String>> {
     let mut merkle_tree = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ impl MerkleTree {
     }
 
     pub fn leaves_amount(&self) -> usize {
-        self.get_level(self.len() - 1).len()
+        self.get_level(self.height() - 1).len()
     }
 
     fn set_element(&mut self, level: usize, index: usize, element: String) {
@@ -82,7 +82,7 @@ impl MerkleTree {
 
         let mut half_merkle_tree = create_merkle_tree_from_leaves(leaves);
         // Push new merkle tree levels into previous one
-        for i in 0..self.len() {
+        for i in 0..self.height() {
             self.merkle_tree[i].append(&mut half_merkle_tree[i]);
         }
 
@@ -95,7 +95,7 @@ impl MerkleTree {
     fn modify_existing_leaf_and_update_parents(&mut self, new_element: Vec<u8>) {
         let mut element_index = self.last_element_index + 1;
         let mut parent_index = element_index / 2;
-        let mut level = self.len() - 1;
+        let mut level = self.height() - 1;
         let mut element_hash = sha256::digest(new_element.clone());
         self.set_element(level, element_index, element_hash.clone());
         while level != 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::vec;
 
 /// sha256::digest("") - the hash of an empty string
 const DEFAULT_ZERO_HASH: &str = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d";
-const DEFAULT_ZERO: [u8; 1] = [0];
+
 
 fn main() {
     println!("Hello, world!");
@@ -97,6 +97,7 @@ impl MerkleTree {
         self.set_last_element_index(next_index);
     }
 
+    #[allow(clippy::needless_range_loop)]
     /// Manages the case when the tree must be extended to add an element.
     fn extend_tree(&mut self, new_element: Vec<u8>) {
         let leaves_amount = self.leaves_amount();
@@ -136,7 +137,7 @@ impl MerkleTree {
         // Insert the new element in the first index that was filled with default data
         self.set_element(level, element_index, element_hash.clone());
 
-        // While we are not in the top level, keep updating the parents 
+        // While we are not in the top level, keep updating the parents
         while level != 0 {
             let concat = match element_index % 2 {
                 0 => element_hash.clone() + self.get_tree_element(level, element_index + 1),
@@ -206,7 +207,7 @@ fn create_data_hashes(inputs: &Input) -> Vec<String> {
 
 /// Given the previous constructed level of the Merkle Tree it allows to create a parent level for it by concatenating
 /// elements in pairs and hashing the results. It is helpful to construct a Merkle Tree from bottom to top.
-fn create_new_level(previous_level: &Vec<String>) -> Vec<String> {
+fn create_new_level(previous_level: &[String]) -> Vec<String> {
     let mut index = 0;
     let mut new_level = Vec::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ impl MerkleTree {
         self.set_last_element_index(next_index);
     }
 
-    #[allow(clippy::needless_range_loop)]
+    #[allow(clippy::needless_range_loop)] // Allow this to make code more understandable
     /// Manages the case when the tree must be extended to add an element.
     fn extend_tree(&mut self, new_element: Vec<u8>) {
         let leaves_amount = self.leaves_amount();
@@ -266,19 +266,7 @@ mod test {
 
         assert_eq!(merkle_tree.height(), 3);
         assert_eq!(merkle_tree.last_element_index(), mock_data.len() - 1);
-        for i in 0..merkle_tree.height() {
-            if i != merkle_tree.height() - 1 {
-                let higher_level = merkle_tree.get_level(i);
-                let lower_level = merkle_tree.get_level(i + 1);
-                for x in 0..higher_level.len() {
-                    let l_child = lower_level[x * 2].clone();
-                    let r_child = lower_level[x * 2 + 1].clone();
-                    let concat_children = l_child + &r_child;
-                    let hashed_children = sha256::digest(concat_children);
-                    assert_eq!(higher_level[x], hashed_children);
-                }
-            }
-        }
+        assert_merkle_tree_is_consistent(merkle_tree);
     }
 
     #[test]
@@ -326,24 +314,41 @@ mod test {
         assert_eq!(data_hashes.len(), mock_data.len().next_power_of_two());
     }
 
+    // Add an element without needing to extend the tree
     #[test]
-    fn add_an_element_1() {
+    fn add_element_in_existing_position() {
         let mock_data = create_mock_data_from_strings(vec!["12345", "6789", "3645738"]);
         let mut merkle_tree = create_merkle_tree_from_data(&mock_data);
-        // should have completed data to four
+        // Should have completed data to four
         assert_eq!(
             merkle_tree.leaves_amount(),
             mock_data.len().next_power_of_two()
         );
         merkle_tree.add_element(b"128746124".to_vec());
-        // should still have same amount of elements
+        // Should still have same amount of elements
         assert_eq!(
             merkle_tree.leaves_amount(),
             mock_data.len().next_power_of_two()
         );
 
+        assert_merkle_tree_is_consistent(merkle_tree);
+    }
+
+    // Add an element by extending the tree
+    #[test]
+    fn add_element_in_new_position() {
+        // Amount of elements is 8 which is 2^3 and tree will no need default data
+        let mock_data = create_mock_data_from_strings(vec!["123", "1234", "12345", "123456", "1234567", "12312458", "1241423", "141251"]);
+        let mut merkle_tree = create_merkle_tree_from_data(&mock_data);
+        let previous_height = merkle_tree.height();
+        assert_eq!(merkle_tree.leaves_amount(), mock_data.len());
         merkle_tree.add_element(b"295873459817".to_vec());
-        assert_eq!(merkle_tree.leaves_amount(), 8);
+        // Make sure the tree had to fill data
+        let new_amount_of_elements = mock_data.len() + 1; // Include the new element
+        assert_ne!(new_amount_of_elements, new_amount_of_elements.next_power_of_two());
+        assert_eq!(merkle_tree.leaves_amount(), new_amount_of_elements.next_power_of_two());
+        assert_eq!(merkle_tree.height(), previous_height + 1); 
+        assert_merkle_tree_is_consistent(merkle_tree);
     }
 
     /// Util Functions
@@ -354,5 +359,23 @@ mod test {
             mock_data.push(bytes);
         }
         mock_data
+    }
+
+    /// Util function to assert every level of the tree is well constructed
+    /// and every element is a hash of its children's concatenation hash
+    fn assert_merkle_tree_is_consistent(merkle_tree: MerkleTree) {
+        for i in 0..merkle_tree.height() {
+            if i != merkle_tree.height() - 1 {
+                let higher_level = merkle_tree.get_level(i);
+                let lower_level = merkle_tree.get_level(i + 1);
+                for x in 0..higher_level.len() {
+                    let l_child = lower_level[x * 2].clone();
+                    let r_child = lower_level[x * 2 + 1].clone();
+                    let concat_children = l_child + &r_child;
+                    let hashed_children = sha256::digest(concat_children);
+                    assert_eq!(higher_level[x], hashed_children);
+                }
+            }
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,11 @@ fn main() {
 
 #[derive(Default)]
 pub struct MerkleTree {
-    merkle_tree: Vec<Vec<String>>,
+    merkle_tree: HashTree,
     last_element_index: usize,
 }
 impl MerkleTree {
-    pub fn new(merkle_tree: Vec<Vec<String>>, last_element_index: usize) -> Self {
+    pub fn new(merkle_tree: HashTree, last_element_index: usize) -> Self {
         MerkleTree {
             merkle_tree,
             last_element_index,

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ impl MerkleTree {
         leaves.append(&mut vec![DEFAULT_ZERO_HASH.to_string(); fill_amount]);
 
         // Create a new merkle tree for the new data subset
-        let mut half_merkle_tree = create_merkle_tree_from_leaves(leaves);
+        let mut half_merkle_tree = create_hash_tree_from_leaves(leaves);
 
         // Append the new merkle tree's levels to the previous tree
         for i in 0..self.height() {
@@ -153,10 +153,10 @@ impl MerkleTree {
 }
 
 type Input = Vec<Vec<u8>>;
-
+type HashTree = Vec<Vec<String>>;
 /// Allows the creation of a Merkle Tree from its base level (or leaves level) which are the hashes of the original
 /// data. This function is useful to extend the Merkle Tree when adding a new element.
-fn create_merkle_tree_from_leaves(leaves: Vec<String>) -> Vec<Vec<String>> {
+fn create_hash_tree_from_leaves(leaves: Vec<String>) -> HashTree {
     let mut merkle_tree = Vec::new();
     merkle_tree.push(leaves.clone());
     let mut previous_level = leaves;
@@ -177,7 +177,7 @@ pub fn create_merkle_tree_from_data(inputs: &Input) -> MerkleTree {
     let mut merkle_tree = MerkleTree::default();
     let data_hashes_level = create_data_hashes(inputs);
 
-    let tree = create_merkle_tree_from_leaves(data_hashes_level);
+    let tree = create_hash_tree_from_leaves(data_hashes_level);
 
     merkle_tree.merkle_tree = tree;
     merkle_tree.set_last_element_index(inputs.len() - 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
-use std::vec;
 use lazy_static::lazy_static;
+use std::vec;
 
 // The hash of the zero value
-lazy_static! { static ref DEFAULT_ZERO_HASH: String = sha256::digest(&[0]); }
+lazy_static! {
+    static ref DEFAULT_ZERO_HASH: String = sha256::digest(&[0]);
+}
 
 fn main() {
     println!("Hello, world!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,43 +61,82 @@ impl MerkleTree {
         self.merkle_tree[level][index] = element;
     }
 
+    /// Allows the addition of a new element to the tree and updates the rest of it accordingly.
+    /// Because the Merkle Tree always has a leaves amount that is a power of two there are two cases to be considered:
+    /// Case 1 -> The tree was filled with default data to reach a power of two
+    ///     In this case, the new element will replace the first default element after the data and consequently its parents
+    ///     will be updated.
+    /// Case 2 -> The tree's current data elements amount naturally reaches a power of two
+    ///     In this case, the tree will need to fill its leaves with default data. This occurs because if we consider N the current number of leaves
+    ///     and N is a power of two (as a rule) then in no case will N + 1 (adding the new element) remain a power of two. Therefore a matching size
+    ///     tree will be constructed to do this and then will be appended to the original tree by calculating a new root that is built from.
+    ///     Consider the example:
+    ///                     R
+    ///                 H1      H2      --> adding a new element will require to have 8 leaves (next power of two).
+    ///             H3  H4      H5 H6
+    /// Therefore another "half tree" is constructed and both are appended converging in a calculated new root
+    ///                                 R'
+    ///                     R1                   R2
+    ///                 H1      H2            H7     H8                 Where everything under R1 is the original tree,
+    ///             H3  H4      H5 H6      H9 H10    H11 H12            everything under R2 is the new subtree and H9 is the hash of the new element
+    ///                                                                 (H10, H11, H12 are default data) and R' is the new calculated root (hash of (R1+R2))
+    ///
     pub fn add_element(&mut self, new_element: Vec<u8>) {
         let next_index = self.last_element_index() + 1;
 
-        // In case the tree already has a data amount that is a power of two, an extension must be done
-        // recalculating fill data
+        // Contemplates Case 2. The element requires a new index past the existing ones and the tree must be extended.
         if next_index == self.leaves_amount() {
             self.extend_tree(new_element);
-        } else {
+        }
+        // Contemplates Case 1. The new element replaces an existing index and the tree must be updated.
+        else {
             self.modify_existing_leaf_and_update_parents(new_element);
         }
+
+        // After any of the cases, the last index with real data must be updated.
         self.set_last_element_index(next_index);
     }
 
+    /// Manages the case when the tree must be extended to add an element.
     fn extend_tree(&mut self, new_element: Vec<u8>) {
         let leaves_amount = self.leaves_amount();
+        // The needed amount of default data to fill the leaves. Given by the calculation:
+        // Example: if the current tree has 4 leaves then:
+        // current_amount_of_leaves + new_leaf = 4 + 1 = 5
+        // next_power_of_two(5) = 8
+        // needed leaves to reach next power of two from current state -> 8 - 4 = 4
+        // taking into account that 1 of those leaves is the actual new data the fill amount is 3
         let fill_amount = ((leaves_amount + 1).next_power_of_two() - leaves_amount) - 1;
+
+        // Create the leaves level of the new subtree
         let mut leaves = vec![sha256::digest(new_element)];
         leaves.append(&mut vec![DEFAULT_ZERO_HASH.to_string(); fill_amount]);
 
+        // Create a new merkle tree for the new data subset
         let mut half_merkle_tree = create_merkle_tree_from_leaves(leaves);
-        // Push new merkle tree levels into previous one
+
+        // Append the new merkle tree's levels to the previous tree
         for i in 0..self.height() {
             self.merkle_tree[i].append(&mut half_merkle_tree[i]);
         }
 
-        // create new zero level
+        // Obtain the new root from the roots of the two subtrees.
         let root =
             sha256::digest(self.get_tree_element(0, 0).clone() + self.get_tree_element(0, 1));
         self.push_level_front(vec![root]);
     }
 
+    /// Manages the case when an element must be added in an existing position and the tree must be updated afterwards.
     fn modify_existing_leaf_and_update_parents(&mut self, new_element: Vec<u8>) {
         let mut element_index = self.last_element_index + 1;
         let mut parent_index = element_index / 2;
         let mut level = self.height() - 1;
         let mut element_hash = sha256::digest(new_element.clone());
+
+        // Insert the new element in the first index that was filled with default data
         self.set_element(level, element_index, element_hash.clone());
+
+        // While we are not in the top level, keep updating the parents 
         while level != 0 {
             let concat = match element_index % 2 {
                 0 => element_hash.clone() + self.get_tree_element(level, element_index + 1),
@@ -114,6 +153,8 @@ impl MerkleTree {
 
 type Input = Vec<Vec<u8>>;
 
+/// Allows the creationg of a Merkle Tree from its base level (or leaves level) which are the hashes of the original
+/// data. This function is useful to extend the Merkle Tree when adding a new element.
 fn create_merkle_tree_from_leaves(leaves: Vec<String>) -> Vec<Vec<String>> {
     let mut merkle_tree = Vec::new();
     merkle_tree.push(leaves.clone());
@@ -129,6 +170,8 @@ fn create_merkle_tree_from_leaves(leaves: Vec<String>) -> Vec<Vec<String>> {
     merkle_tree
 }
 
+/// Allows the creation of a Merkle Tree from a vector of buffers as data elements. If necessary, it will add default
+/// data elements to the leaves level so the amount is a power of two
 pub fn create_merkle_tree_from_data(inputs: &Input) -> MerkleTree {
     let mut merkle_tree = MerkleTree::default();
     let data_hashes_level = create_data_hashes(inputs);
@@ -140,6 +183,9 @@ pub fn create_merkle_tree_from_data(inputs: &Input) -> MerkleTree {
     merkle_tree
 }
 
+/// Creates the leaves level from a specific input. Meaning it hashes every data element from the input and returns
+/// a vector of those hashes that can later be used as the lower level of the tree.
+/// Notice that it fills with default elements if necessary to reach an amount that is a power of two.
 fn create_data_hashes(inputs: &Input) -> Vec<String> {
     let mut data_hashes = Vec::new();
 
@@ -158,7 +204,9 @@ fn create_data_hashes(inputs: &Input) -> Vec<String> {
     data_hashes
 }
 
-fn create_new_level(previous_level: &[String]) -> Vec<String> {
+/// Given the previous constructed level of the Merkle Tree it allows to create a parent level for it by concatenating
+/// elements in pairs and hashing the results. It is helpful to construct a Merkle Tree from bottom to top.
+fn create_new_level(previous_level: &Vec<String>) -> Vec<String> {
     let mut index = 0;
     let mut new_level = Vec::new();
 
@@ -172,6 +220,8 @@ fn create_new_level(previous_level: &[String]) -> Vec<String> {
     new_level
 }
 
+/// Given a proof provided by the Merkle Tree it allows to verify that a certain element has been stored at a certain index
+/// in the Merkle Tree.
 pub fn verify_element(
     element_data: Vec<u8>,
     proof: &Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use std::vec;
 /// sha256::digest("") - the hash of an empty string
 const DEFAULT_ZERO_HASH: &str = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d";
 
-
 fn main() {
     println!("Hello, world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,11 +116,11 @@ impl MerkleTree {
         leaves.append(&mut vec![DEFAULT_ZERO_HASH.to_string(); fill_amount]);
 
         // Create a new merkle tree for the new data subset
-        let mut half_merkle_tree = create_hash_tree_from_leaves(leaves);
+        let half_merkle_tree = create_hash_tree_from_leaves(leaves);
 
         // Append the new merkle tree's levels to the previous tree
         for i in 0..self.height() {
-            self.merkle_tree[i].append(&mut half_merkle_tree[i]);
+            self.merkle_tree[i].extend_from_slice(&half_merkle_tree[i]);
         }
 
         // Obtain the new root from the roots of the two subtrees.

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,16 +338,24 @@ mod test {
     #[test]
     fn add_element_in_new_position() {
         // Amount of elements is 8 which is 2^3 and tree will no need default data
-        let mock_data = create_mock_data_from_strings(vec!["123", "1234", "12345", "123456", "1234567", "12312458", "1241423", "141251"]);
+        let mock_data = create_mock_data_from_strings(vec![
+            "123", "1234", "12345", "123456", "1234567", "12312458", "1241423", "141251",
+        ]);
         let mut merkle_tree = create_merkle_tree_from_data(&mock_data);
         let previous_height = merkle_tree.height();
         assert_eq!(merkle_tree.leaves_amount(), mock_data.len());
         merkle_tree.add_element(b"295873459817".to_vec());
         // Make sure the tree had to fill data
         let new_amount_of_elements = mock_data.len() + 1; // Include the new element
-        assert_ne!(new_amount_of_elements, new_amount_of_elements.next_power_of_two());
-        assert_eq!(merkle_tree.leaves_amount(), new_amount_of_elements.next_power_of_two());
-        assert_eq!(merkle_tree.height(), previous_height + 1); 
+        assert_ne!(
+            new_amount_of_elements,
+            new_amount_of_elements.next_power_of_two()
+        );
+        assert_eq!(
+            merkle_tree.leaves_amount(),
+            new_amount_of_elements.next_power_of_two()
+        );
+        assert_eq!(merkle_tree.height(), previous_height + 1);
         assert_merkle_tree_is_consistent(merkle_tree);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use std::vec;
+use lazy_static::lazy_static;
 
-/// sha256::digest("") - the hash of an empty string
-const DEFAULT_ZERO_HASH: &str = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d";
+// The hash of the zero value
+lazy_static! { static ref DEFAULT_ZERO_HASH: String = sha256::digest(&[0]); }
 
 fn main() {
     println!("Hello, world!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
+use std::vec;
+
 /// sha256::digest("") - the hash of an empty string
-const DEFAULT_HASH_OF_EMTPY: &str =
-    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+const DEFAULT_ZERO_HASH: &str = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d";
+const DEFAULT_ZERO: [u8; 1] = [0];
 
 fn main() {
     println!("Hello, world!");
@@ -50,25 +52,90 @@ impl MerkleTree {
     pub fn is_empty(&self) -> bool {
         self.merkle_tree.is_empty()
     }
+
+    pub fn leaves_amount(&self) -> usize {
+        self.get_level(self.len() - 1).len()
+    }
+
+    fn set_element(&mut self, level: usize, index: usize, element: String) {
+        self.merkle_tree[level][index] = element;
+    }
+
+    pub fn add_element(&mut self, new_element: Vec<u8>) {
+        let next_index = self.last_element_index() + 1;
+
+        // In case the tree already has a data amount that is a power of two, an extension must be done
+        // recalculating fill data
+        if next_index == self.leaves_amount() {
+            self.extend_tree(new_element);
+        } else {
+            self.modify_existing_leaf_and_update_parents(new_element);
+        }
+        self.set_last_element_index(next_index);
+    }
+
+    fn extend_tree(&mut self, new_element: Vec<u8>) {
+        let leaves_amount = self.leaves_amount();
+        let fill_amount = ((leaves_amount + 1).next_power_of_two() - leaves_amount) - 1;
+        let mut leaves = vec![sha256::digest(new_element)];
+        leaves.append(&mut vec![DEFAULT_ZERO_HASH.to_string(); fill_amount]);
+
+        let mut half_merkle_tree = create_merkle_tree_from_leaves(leaves);
+        // Push new merkle tree levels into previous one
+        for i in 0..self.len() {
+            self.merkle_tree[i].append(&mut half_merkle_tree[i]);
+        }
+
+        // create new zero level
+        let root =
+            sha256::digest(self.get_tree_element(0, 0).clone() + self.get_tree_element(0, 1));
+        self.push_level_front(vec![root]);
+    }
+
+    fn modify_existing_leaf_and_update_parents(&mut self, new_element: Vec<u8>) {
+        let mut element_index = self.last_element_index + 1;
+        let mut parent_index = element_index / 2;
+        let mut level = self.len() - 1;
+        let mut element_hash = sha256::digest(new_element.clone());
+        self.set_element(level, element_index, element_hash.clone());
+        while level != 0 {
+            let concat = match element_index % 2 {
+                0 => element_hash.clone() + self.get_tree_element(level, element_index + 1),
+                _ => self.get_tree_element(level, element_index - 1).clone() + &element_hash,
+            };
+            element_hash = sha256::digest(concat);
+            self.set_element(level - 1, parent_index, element_hash.clone());
+            level -= 1;
+            element_index = parent_index;
+            parent_index = element_index / 2;
+        }
+    }
 }
 
 type Input = Vec<Vec<u8>>;
 
-pub fn create_merkle_tree_from_data(inputs: &Input) -> MerkleTree {
-    let mut merkle_tree = MerkleTree::default();
-    let data_hashes_level = create_data_hashes(inputs);
-    merkle_tree.push_level_back(data_hashes_level.clone());
-
-    let mut previous_level = data_hashes_level;
+fn create_merkle_tree_from_leaves(leaves: Vec<String>) -> Vec<Vec<String>> {
+    let mut merkle_tree = Vec::new();
+    merkle_tree.push(leaves.clone());
+    let mut previous_level = leaves;
     let mut level_len = previous_level.len();
 
     while level_len != 1 {
         let new_level = create_new_level(&previous_level);
-        merkle_tree.push_level_front(new_level.clone());
+        merkle_tree.insert(0, new_level.clone());
         previous_level = new_level;
         level_len = previous_level.len();
     }
+    merkle_tree
+}
 
+pub fn create_merkle_tree_from_data(inputs: &Input) -> MerkleTree {
+    let mut merkle_tree = MerkleTree::default();
+    let data_hashes_level = create_data_hashes(inputs);
+
+    let tree = create_merkle_tree_from_leaves(data_hashes_level);
+
+    merkle_tree.merkle_tree = tree;
     merkle_tree.set_last_element_index(inputs.len() - 1);
     merkle_tree
 }
@@ -83,7 +150,7 @@ fn create_data_hashes(inputs: &Input) -> Vec<String> {
     if !data_len.is_power_of_two() {
         let fill_amount = data_len.next_power_of_two() - data_len;
         data_hashes.append(&mut vec![
-            DEFAULT_HASH_OF_EMTPY.to_string().clone();
+            DEFAULT_ZERO_HASH.to_string().clone();
             fill_amount
         ]);
     }
@@ -204,9 +271,29 @@ mod test {
         assert!(
             default_data
                 .iter()
-                .all(|x| *x == DEFAULT_HASH_OF_EMTPY.to_string())
+                .all(|x| *x == DEFAULT_ZERO_HASH.to_string())
         );
         assert_eq!(data_hashes.len(), mock_data.len().next_power_of_two());
+    }
+
+    #[test]
+    fn add_an_element_1() {
+        let mock_data = create_mock_data_from_strings(vec!["12345", "6789", "3645738"]);
+        let mut merkle_tree = create_merkle_tree_from_data(&mock_data);
+        // should have completed data to four
+        assert_eq!(
+            merkle_tree.leaves_amount(),
+            mock_data.len().next_power_of_two()
+        );
+        merkle_tree.add_element(b"128746124".to_vec());
+        // should still have same amount of elements
+        assert_eq!(
+            merkle_tree.leaves_amount(),
+            mock_data.len().next_power_of_two()
+        );
+
+        merkle_tree.add_element(b"295873459817".to_vec());
+        assert_eq!(merkle_tree.leaves_amount(), 8);
     }
 
     /// Util Functions


### PR DESCRIPTION
This PR includes the necessary changes to admit the possibility to add an element to an existing tree. 
New relevant functions: 
- `add_element()` : allows to include a new element in an existing merkle tree 
- `extend_tree()`: handles the case when the tree's leaves are all full of real data and the tree needs to be extended in order to add a new element. 
- `modify_existing_leaf_and_update_parents()`: handles the case where at least one of the leaves of the tree is filled with default data and the new element replaces it and updates the tree all the way up (recalculating parents' hashes). 
- `create_merkle_tree_from_leaves()`: allows the creation of a merkle tree from its leaves (hashes of the data elements) rather than the elements themselves. This function becomes useful when extending a merkle tree. 

This PR does not include a modules restructure that might occur in a later iteration. 