### PR TITLE
Generate proof

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ impl MerkleTree {
             }
             let proof_element = self.get_tree_element(level, element_index).clone();
             proof.push(proof_element);
-            level = level - 1;
+            level -= 1;
             element_index /= 2;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ impl MerkleTree {
 
     /// Provides an vector of hashes known as "proof" that give a user the possibility to verify
     /// that an element in a specific index is a part of the tree. This pairs with the `verify_element`
-    /// function to prove an element is a part of a tree. 
+    /// function to prove an element is a part of a tree.
     pub fn get_merkle_proof(&self, element_index: usize) -> Vec<String> {
         let mut proof = Vec::new();
         let mut element_index = element_index;
@@ -173,6 +173,10 @@ impl MerkleTree {
         }
 
         proof
+    }
+
+    pub fn get_root(&self) -> String {
+        self.get_tree_element(0, 0).clone()
     }
 }
 
@@ -332,6 +336,18 @@ mod test {
                 .all(|x| *x == DEFAULT_ZERO_HASH.to_string())
         );
         assert_eq!(data_hashes.len(), mock_data.len().next_power_of_two());
+    }
+
+    #[test]
+    fn get_merkle_proof() {
+        let mock_data = create_mock_data_from_strings(vec!["data1", "data2", "data3", "data4", "data5"]);
+        let merkle_tree = create_merkle_tree_from_data(&mock_data);
+        // We want to verify that "data3" is a part of the tree
+        let merkle_proof = merkle_tree.get_merkle_proof(2);
+        assert_eq!(merkle_proof.len(), merkle_tree.leaves_amount().ilog2() as usize);
+        assert!(verify_element(mock_data[2].clone(), &merkle_proof, merkle_tree.get_root(), 2));
+        assert!(!verify_element(mock_data[3].clone(), &merkle_proof, merkle_tree.get_root(), 3));
+
     }
 
     // Add an element without needing to extend the tree

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,14 +340,27 @@ mod test {
 
     #[test]
     fn get_merkle_proof() {
-        let mock_data = create_mock_data_from_strings(vec!["data1", "data2", "data3", "data4", "data5"]);
+        let mock_data =
+            create_mock_data_from_strings(vec!["data1", "data2", "data3", "data4", "data5"]);
         let merkle_tree = create_merkle_tree_from_data(&mock_data);
         // We want to verify that "data3" is a part of the tree
         let merkle_proof = merkle_tree.get_merkle_proof(2);
-        assert_eq!(merkle_proof.len(), merkle_tree.leaves_amount().ilog2() as usize);
-        assert!(verify_element(mock_data[2].clone(), &merkle_proof, merkle_tree.get_root(), 2));
-        assert!(!verify_element(mock_data[3].clone(), &merkle_proof, merkle_tree.get_root(), 3));
-
+        assert_eq!(
+            merkle_proof.len(),
+            merkle_tree.leaves_amount().ilog2() as usize
+        );
+        assert!(verify_element(
+            mock_data[2].clone(),
+            &merkle_proof,
+            merkle_tree.get_root(),
+            2
+        ));
+        assert!(!verify_element(
+            mock_data[3].clone(),
+            &merkle_proof,
+            merkle_tree.get_root(),
+            3
+        ));
     }
 
     // Add an element without needing to extend the tree

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,6 @@ pub struct MerkleTree {
     last_element_index: usize,
 }
 impl MerkleTree {
-
-
     pub fn new(merkle_tree: HashTree, last_element_index: usize) -> Self {
         MerkleTree {
             merkle_tree,
@@ -155,7 +153,7 @@ impl MerkleTree {
         }
     }
 
-      pub fn get_merkle_proof(&self, element_index: usize) -> Vec<String> {
+    pub fn get_merkle_proof(&self, element_index: usize) -> Vec<String> {
         let mut proof = Vec::new();
         let mut element_index = element_index;
         let mut level = self.height() - 1;
@@ -173,7 +171,6 @@ impl MerkleTree {
 
         proof
     }
-
 }
 
 type Input = Vec<Vec<u8>>;
@@ -265,7 +262,6 @@ pub fn verify_element(
     }
     hash == root
 }
-
 
 #[cfg(test)]
 mod test {

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,9 @@ impl MerkleTree {
         }
     }
 
+    /// Provides an vector of hashes known as "proof" that give a user the possibility to verify
+    /// that an element in a specific index is a part of the tree. This pairs with the `verify_element`
+    /// function to prove an element is a part of a tree. 
     pub fn get_merkle_proof(&self, element_index: usize) -> Vec<String> {
         let mut proof = Vec::new();
         let mut element_index = element_index;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 use std::vec;
 
-/// sha256::digest("") - the hash of an empty string
+/// sha256::digest(&[0]) - the hash of 0
 const DEFAULT_ZERO_HASH: &str = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d";
-const DEFAULT_ZERO: [u8; 1] = [0];
 
 fn main() {
     println!("Hello, world!");
@@ -14,6 +13,26 @@ pub struct MerkleTree {
     last_element_index: usize,
 }
 impl MerkleTree {
+
+    pub fn get_merkle_proof(&self, element_index: usize) -> Vec<String> {
+        let mut proof = Vec::new();
+        let mut element_index = element_index;
+        let mut level = self.height() - 1;
+
+        while level != 0 {
+            match element_index % 2 {
+                0 => element_index += 1,
+                _ => element_index -= 1,
+            }
+            let proof_element = self.get_tree_element(level, element_index).clone();
+            proof.push(proof_element);
+            level = level - 1;
+            element_index /= 2;
+        }
+
+        proof
+    }
+
     pub fn new(merkle_tree: Vec<Vec<String>>, last_element_index: usize) -> Self {
         MerkleTree {
             merkle_tree,
@@ -98,6 +117,7 @@ impl MerkleTree {
         let mut level = self.height() - 1;
         let mut element_hash = sha256::digest(new_element.clone());
         self.set_element(level, element_index, element_hash.clone());
+
         while level != 0 {
             let concat = match element_index % 2 {
                 0 => element_hash.clone() + self.get_tree_element(level, element_index + 1),
@@ -191,6 +211,7 @@ pub fn verify_element(
     hash == root
 }
 
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -236,12 +257,10 @@ mod test {
         let mock_data = create_mock_data_from_strings(vec!["12313414", "1345", "124214", "125151"]);
         let merkle_tree = create_merkle_tree_from_data(&mock_data);
 
+        let proof = merkle_tree.get_merkle_proof(0);
         let mut is_element_present = verify_element(
             mock_data[0].clone(),
-            &vec![
-                merkle_tree.get_tree_element(2, 1).clone(),
-                merkle_tree.get_tree_element(1, 1).clone(),
-            ],
+            &proof,
             merkle_tree.get_tree_element(0, 0).clone(),
             0,
         );
@@ -249,10 +268,7 @@ mod test {
 
         is_element_present = verify_element(
             b"absent_element".to_vec(),
-            &vec![
-                merkle_tree.get_tree_element(2, 1).clone(),
-                merkle_tree.get_tree_element(1, 1).clone(),
-            ],
+            &proof,
             merkle_tree.get_tree_element(0, 0).clone(),
             0,
         );


### PR DESCRIPTION
This PR add the function `get_merkle_proof()` that given an index of an element returns the necessary hashes in a vector that will allow the user to verify the element is part of the tree. 