### PR TITLE
add missing line to be able to import as a lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "rusty-merkle-tree"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+path = "src/merkle_tree.rs"
+
 [dependencies]
 lazy_static = "1.5.0"
 sha256 = "1.6.0"


### PR DESCRIPTION
Add missing line in `Cargo.toml` to be able to import as a library in other projects.  